### PR TITLE
packaging: grafana SSO with internal Keycloak

### DIFF
--- a/packaging/conf/grafana.ini.in
+++ b/packaging/conf/grafana.ini.in
@@ -375,11 +375,12 @@ enabled = true
 allow_sign_up = false
 client_id = @OVIRT_GRAFANA_SSO_CLIENT_ID@
 client_secret = """@OVIRT_GRAFANA_SSO_CLIENT_SECRET@"""
-scopes = ovirt-app-admin,ovirt-app-portal,ovirt-ext=auth:sequence-priority=~
+scopes = @SCOPES@
+role_attribute_path = @ROLE_ATTRIBUTE_PATH@
 email_attribute_name = email
-auth_url = @ENGINE_SSO_AUTH_URL@/openid/authorize
-token_url = @ENGINE_SSO_AUTH_URL@/openid/token
-api_url = @ENGINE_SSO_AUTH_URL@/openid/userinfo
+auth_url = @SSO_AUTH_URL@
+token_url = @SSO_TOKEN_URL@
+api_url = @SSO_API_URL@
 team_ids =
 allowed_organizations =
 tls_skip_verify_insecure = false

--- a/packaging/setup/ovirt_engine_setup/grafana_dwh/constants.py
+++ b/packaging/setup/ovirt_engine_setup/grafana_dwh/constants.py
@@ -226,6 +226,7 @@ class FileLocations(oengcommcons.FileLocations):
 @util.export
 class Stages(object):
     CORE_ENABLE = 'osetup.grafana.core.enable'
+    GRAFANA_CONFIG = 'osetup.grafana.config'
     DB_GRAFANA_CONNECTION_CUSTOMIZATION = \
         'osetup.grafana.db.connection.customization'
     DB_CONNECTION_SETUP = 'osetup.grafana.db.connection.setup'
@@ -330,6 +331,28 @@ class RemoveEnv(object):
 class RPMDistroEnv(object):
     ADDITIONAL_PACKAGES = 'OVESETUP_GRAFANA_RPMDISTRO/additionalPackages'
     PACKAGES_SETUP = 'OVESETUP_GRAFANA_RPMDISRO_PACKAGES_SETUP'
+
+
+@util.export
+@util.codegen
+@osetupattrsclass
+class KeycloakEnv(object):
+    KEYCLOAK_ENABLED = 'OVESETUP_GRAFANA_CONFIG/keycloakEnabled'
+    KEYCLOAK_AUTH_URL = 'OVESETUP_GRAFANA_CONFIG/keycloakAuthUrl'
+    KEYCLOAK_TOKEN_URL = 'OVESETUP_GRAFANA_CONFIG/keycloakTokenUrl'
+    KEYCLOAK_USERINFO_URL = 'OVESETUP_GRAFANA_CONFIG/keycloakUserinfoUrl'
+    KEYCLOAK_GRAFANA_ADMIN_ROLE = 'OVESETUP_GRAFANA_CONFIG/keycloakGrafanaAdminRole'
+    KEYCLOAK_GRAFANA_EDITOR_ROLE = 'OVESETUP_GRAFANA_CONFIG/keycloakGrafanaEditorRole'
+    KEYCLOAK_GRAFANA_VIEWER_ROLE = 'OVESETUP_GRAFANA_CONFIG/keycloakGrafanaViewerRole'
+
+    @osetupattrs(
+        is_secret=True,
+    )
+    def KEYCLOAK_OVIRT_INTERNAL_CLIENT_SECRET(self):
+        return 'OVESETUP_GRAFANA_CONFIG/keycloakOvirtClientSecret'
+
+    KEYCLOAK_OVIRT_INTERNAL_CLIENT_ID = \
+        'OVESETUP_GRAFANA_CONFIG/keycloakOvirtClientId'
 
 
 # vim: expandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
This patch adds support for Keycloak based SSO.
Similarly to ovirt engine, the support is enabled only when
ovirt-engine-keycloak-setup package is installed (upstream only, non
developer mode)