### PR TITLE
Fix Grafana proxy configuration

### DIFF
--- a/packaging/conf/httpd-grafana-proxy.conf.in
+++ b/packaging/conf/httpd-grafana-proxy.conf.in
@@ -3,6 +3,7 @@
 </IfModule>
 
 <Location @GRAFANA_URI_PATH@>
+    ProxyPreserveHost on
     ProxyPass http://127.0.0.1:@GRAFANA_PORT@ retry=0 disablereuse=On
     ProxyPassReverse http://127.0.0.1:@GRAFANA_PORT@@GRAFANA_URI_PATH@
 </Location>


### PR DESCRIPTION
There is a grafana update in version 7.5.15 used on CS8.
We need to pass the original Host and Origin headers from the client request to Grafana.

Signed-off-by: Aviv Litman <alitman@redhat.com>