### PR TITLE
Reconfigure SSO on keycloak activation

### DIFF
--- a/packaging/setup/ovirt_engine_setup/grafana_dwh/constants.py
+++ b/packaging/setup/ovirt_engine_setup/grafana_dwh/constants.py
@@ -333,26 +333,4 @@ class RPMDistroEnv(object):
     PACKAGES_SETUP = 'OVESETUP_GRAFANA_RPMDISRO_PACKAGES_SETUP'
 
 
-@util.export
-@util.codegen
-@osetupattrsclass
-class KeycloakEnv(object):
-    KEYCLOAK_ENABLED = 'OVESETUP_GRAFANA_CONFIG/keycloakEnabled'
-    KEYCLOAK_AUTH_URL = 'OVESETUP_GRAFANA_CONFIG/keycloakAuthUrl'
-    KEYCLOAK_TOKEN_URL = 'OVESETUP_GRAFANA_CONFIG/keycloakTokenUrl'
-    KEYCLOAK_USERINFO_URL = 'OVESETUP_GRAFANA_CONFIG/keycloakUserinfoUrl'
-    KEYCLOAK_GRAFANA_ADMIN_ROLE = 'OVESETUP_GRAFANA_CONFIG/keycloakGrafanaAdminRole'
-    KEYCLOAK_GRAFANA_EDITOR_ROLE = 'OVESETUP_GRAFANA_CONFIG/keycloakGrafanaEditorRole'
-    KEYCLOAK_GRAFANA_VIEWER_ROLE = 'OVESETUP_GRAFANA_CONFIG/keycloakGrafanaViewerRole'
-
-    @osetupattrs(
-        is_secret=True,
-    )
-    def KEYCLOAK_OVIRT_INTERNAL_CLIENT_SECRET(self):
-        return 'OVESETUP_GRAFANA_CONFIG/keycloakOvirtClientSecret'
-
-    KEYCLOAK_OVIRT_INTERNAL_CLIENT_ID = \
-        'OVESETUP_GRAFANA_CONFIG/keycloakOvirtClientId'
-
-
 # vim: expandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
This patch makes sure that ovirt oauth sso configuration in
`/etc/grafana/grafana.ini` gets updated to use ovirt engine internal
keycloak.

This feature originally was only supporting new installations, now it
allows to enable keycloak on existing ovirt engine installations and
setups grafana to make use of ovirt internal sso.

This patch should be merged alongside with:
* https://github.com/oVirt/ovirt-engine-keycloak/pull/38