### PR TITLE
packaging: setup: Always initialize self._remote_engine

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-grafana-dwh/core/config.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-grafana-dwh/core/config.py
@@ -168,6 +168,16 @@ class Plugin(plugin.PluginBase):
         )
 
     @plugin.event(
+        stage=plugin.Stages.STAGE_LATE_SETUP,
+        # env[REMOTE_ENGINE] is created in common engine-setup code,
+        # in STAGE_SETUP. So here in STAGE_LATE_SETUP is good enough.
+    )
+    def _late_setup_remote_engine(self):
+        self._remote_engine = self.environment[
+            osetupcons.CoreEnv.REMOTE_ENGINE
+        ]
+
+    @plugin.event(
         stage=plugin.Stages.STAGE_CUSTOMIZATION,
         before=(
             osetupcons.Stages.DIALOG_TITLES_E_MISC,
@@ -184,9 +194,6 @@ class Plugin(plugin.PluginBase):
         if self.environment[oenginecons.CoreEnv.ENABLE]:
             self._register_sso_client = True
         else:
-            self._remote_engine = self.environment[
-                osetupcons.CoreEnv.REMOTE_ENGINE
-            ]
             fd, tmpconf = tempfile.mkstemp()
             atexit.register(os.unlink, tmpconf)
             cmd = self._get_sso_client_registration_cmd(tmpconf)


### PR DESCRIPTION
A previous patch removed a condition from _closeup_engine_grafana_access
that made it run only when we were creating a new grafana DB.

On upgrade, when we do not create a DB, self._remote_engine was never
initialized, so making engine-setup fail in
_closeup_engine_grafana_access with:

    'Plugin' object has no attribute '_remote_engine'

Fix this by moving the initialization of self._remote_engine to run
always.

Change-Id: I82372d0ee595ec093f974aea91ed542432650593
Signed-off-by: Yedidyah Bar David <didi@redhat.com>