### PR TITLE
packaging: setup: Fix the call to ok_to_renew_cert

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-grafana-dwh/pki/apache.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-grafana-dwh/pki/apache.py
@@ -105,7 +105,9 @@ class Plugin(plugin.PluginBase):
                 oengcommcons.FileLocations.OVIRT_ENGINE_PKI_APACHE_CA_CERT
             ),
             'apache',
-            True
+            True,
+            True,
+            self.environment,
         ):
             renew = dialog.queryBoolean(
                 dialog=self.dialog,


### PR DESCRIPTION
ok_to_renew_cert now requires two more parameters - "short_life", which
tells whether the cert's life should be (relatively) short (e.g. for a
web server) or can be long (e.g. for engine<->hosts communications), and
"environment", which is used to check the value of
CertExpirationWarnPeriodInDays (the "long" life one).

Please note, that the use, there, of environment[ENGINE_DB_ENV_KEYS],
breaks us if grafana is set up separately from both the engine and dwh.
The documentation currently tells to configure grafana either on the
engine machine or on the dwh machine (if they are separate), but nothing
thus far prevented configuring it on a third machine. This will now
break.

Change-Id: I274917c7452c42bc3f3f05446677154852f847e1
Signed-off-by: Yedidyah Bar David <didi@redhat.com>