### PR TITLE
Sync changes from 4.5.5 release in specific branch

### DIFF
--- a/ovirt-engine-dwh.spec.in
+++ b/ovirt-engine-dwh.spec.in
@@ -267,6 +267,11 @@ touch "%{buildroot}%{_sysconfdir}/ovirt-engine/ovirt-engine-dwh/Default.properti
 %{_sysconfdir}/grafana/conf/
 
 %changelog
+* Thu Sep 01 2022 Martin Perina <mperina@redhat.com> - 4.5.5
+- packaging: setup: Fix the call to ok_to_renew_cert
+- Fix type error in _customization_sso
+- Bug 2122174 - Perform remote engine operations before clean up
+
 * Wed Aug 3 2022 Aviv Litman <alitman@redhat.com> - 4.5.4
 - Bug 2113980 - packaging: setup: Refine the condition on _closeup_engine_grafana_acc…
 

--- a/version.mak
+++ b/version.mak
@@ -6,7 +6,7 @@
 # increment after releasing/branching
 VERSION_MAJOR=4
 VERSION_MINOR=5
-VERSION_PATCH_LEVEL=5
+VERSION_PATCH_LEVEL=6
 VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH_LEVEL)
 
 # Milestone is manually specified,


### PR DESCRIPTION
Sync changes from 4.5.5 release, which has been created in
ovirt-engine-dwh-4.5.5.z branch

Signed-off-by: Martin Perina <mperina@redhat.com>
