### PR TITLE
Revert "Fix type error in _customization_sso"

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-grafana-dwh/core/config.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-grafana-dwh/core/config.py
@@ -220,7 +220,7 @@ class Plugin(plugin.PluginBase):
                 prompt=True,
                 default=True,
             )
-            with open(tmpconf, 'w') as f:
+            with open(tmpconf, 'wb') as f:
                 f.write(res)
             self._process_sso_client_registration_result(tmpconf)
 


### PR DESCRIPTION
This reverts commit 40b2df1ce99603e0f351c4ef27bf7259b28c7e79.

I think that patch was merged to fix a bug in manual_files, but broke root_ssh. [2] is an alternative, which should make both work.

[2] https://github.com/oVirt/ovirt-engine/pull/645