### PR TITLE
packaging: setup: Fix configuring grafana with keycloak

### DIFF
--- a/ovirt-engine-dwh.spec.in
+++ b/ovirt-engine-dwh.spec.in
@@ -152,7 +152,7 @@ Requires:       postgresql-contrib >= 12.0
 %package grafana-integration-setup
 Summary:	%{product_name} Grafana integration setup
 Group:		Virtualization/Management
-Requires:	ovirt-engine-setup-plugin-ovirt-engine-common >= 4.5.3
+Requires:	ovirt-engine-setup-plugin-ovirt-engine-common >= 4.5.4
 Requires:	%{name}-setup = %{version}-%{release}
 Requires:	((grafana >= 7.3 and grafana < 9.2.10-10) or (grafana >= 9.2.10-15))
 Requires:	httpd


### PR DESCRIPTION
With this flow:
1. Setup an engine with keycloak, no dwh/grafana
2. engine-setup --reconfigure-optional-components, enable dwh+grafana

keycloak is already configured, but we do want to configure grafana to use keycloak. So remove the condition that we only do this if keycloak is not configured yet.

Change-Id: I019335c60f686d139da0e9368147e035db75ba37
Signed-off-by: Yedidyah Bar David <didi@redhat.com>