### PR TITLE
etltermination: wait for main thread to end

### DIFF
--- a/etl_export/src/main/java/ovirt_engine_dwh/historyetl_4_5/HistoryETL.java
+++ b/etl_export/src/main/java/ovirt_engine_dwh/historyetl_4_5/HistoryETL.java
@@ -11390,6 +11390,7 @@ public class HistoryETL implements TalendJob {
 
 		int exitCode = HistoryETLClass.runJobInTOS(args);
 
+		org.ovirt.engine.dwh.etltermination.Termination.getInstance().stop();
 		System.exit(exitCode);
 	}
 

--- a/ovirt-engine-dwh/etltermination/src/main/java/org/ovirt/engine/dwh/etltermination/Termination.java
+++ b/ovirt-engine-dwh/etltermination/src/main/java/org/ovirt/engine/dwh/etltermination/Termination.java
@@ -5,6 +5,7 @@ public class Termination {
     private static volatile Termination instance;
 
     private boolean terminate;
+    private boolean stop;
 
     public static Termination getInstance() {
         if (instance == null) {
@@ -19,8 +20,16 @@ public class Termination {
 
     private Termination() {
         terminate = false;
+
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             terminate = true;
+            try {
+                while (!stop) {
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }));
     }
 
@@ -28,4 +37,7 @@ public class Termination {
         return terminate;
     }
 
+    public void stop() {
+        stop = true;
+    }
 }


### PR DESCRIPTION
We should wait until the main thread ends.
Otherwise we stop early, and not everything is correctly handled.