### PR TITLE
service: add graceful shutdown

### DIFF
--- a/ovirt-engine-dwh.spec.in
+++ b/ovirt-engine-dwh.spec.in
@@ -102,6 +102,7 @@ Requires:	jackson-databind
 Requires:	jackson-annotations
 Requires:	logrotate
 Requires:	postgresql-jdbc
+Requires:	python3-psycopg2
 
 Requires:       postgresql-server >= 12.0
 Requires:       postgresql-contrib >= 12.0
@@ -118,7 +119,7 @@ Requires(postun):	systemd
 %package setup
 Summary:	%{product_name} setup
 Group:		Virtualization/Management
-Requires:	ovirt-engine-setup-plugin-ovirt-engine-common >= 4.5.0
+Requires:	ovirt-engine-setup-plugin-ovirt-engine-common >= 4.5.7
 Requires:	%{name}-grafana-integration-setup = %{version}-%{release}
 BuildRequires:	python3
 BuildRequires:	python3-devel

--- a/packaging/services/ovirt-engine-dwhd/ovirt-engine-dwhd.py
+++ b/packaging/services/ovirt-engine-dwhd/ovirt-engine-dwhd.py
@@ -100,6 +100,60 @@ class Daemon(service.Daemon):
                 mustExist=False,
             )
 
+    def _executeEngineDbQuery(self, query, params, operation_description):
+        """
+        Execute a query on the engine database.
+        
+        Args:
+            query: SQL query string
+            params: Tuple of parameters for the query
+            operation_description: Description of the operation for logging
+            
+        Returns:
+            True on success, False on failure
+        """
+        try:
+            import psycopg2
+            
+            conn = psycopg2.connect(
+                host=self._config.get('ENGINE_DB_HOST'),
+                port=self._config.get('ENGINE_DB_PORT'),
+                database=self._config.get('ENGINE_DB_DATABASE'),
+                user=self._config.get('ENGINE_DB_USER'),
+                password=self._config.get('ENGINE_DB_PASSWORD'),
+                connect_timeout=10
+            )
+            
+            try:
+                cur = conn.cursor()
+                cur.execute(query, params)
+                conn.commit()
+                cur.close()
+                
+                self.logger.debug('Successfully %s', operation_description)
+                return True
+            finally:
+                conn.close()
+                
+        except ImportError:
+            self.logger.warning(
+                'psycopg2 module not available, cannot %s', operation_description
+            )
+            return False
+        except Exception as e:
+            self.logger.warning(
+                'Exception while %s: %s', operation_description, e
+            )
+            return False
+
+    def externalProcessGracefulShutdown(self, process):
+        self.logger.info('Setting DisconnectDwh flag to request graceful shutdown')
+        return self._executeEngineDbQuery(
+            "UPDATE vdc_options SET option_value = %s WHERE option_name = %s",
+            ('1', 'DisconnectDwh'),
+            'set DisconnectDwh flag to 1'
+        )
+
     def daemonSetup(self):
 
         if os.geteuid() == 0:
@@ -228,6 +282,13 @@ class Daemon(service.Daemon):
         return (consoleLog, consoleLog)
 
     def daemonContext(self):
+        self.logger.info('Resetting DisconnectDwh flag to 0')
+        self._executeEngineDbQuery(
+            "UPDATE vdc_options SET option_value = %s WHERE option_name = %s",
+            ('0', 'DisconnectDwh'),
+            'reset DisconnectDwh flag to 0'
+        )
+
         self.daemonAsExternalProcess(
             executable=self._executable,
             args=self._serviceArgs,


### PR DESCRIPTION
Attempt to graceful shutdown when signal is received. i.e. instead of sending a signal to jvm, set DisconnectDwh to 1 in the engine database. This will make dwh cleanly finish what it is doing and shut down. At startup we set the DisconnectDwh back to 0, otherwise dwh would immediately be stopped again.

Needs: https://github.com/oVirt/ovirt-engine/pull/1098