### PR TITLE
service: let shutdownhook wait for stop

### DIFF
--- a/etl_export/src/main/java/ovirt_engine_dwh/historyetl_4_5/HistoryETL.java
+++ b/etl_export/src/main/java/ovirt_engine_dwh/historyetl_4_5/HistoryETL.java
@@ -11390,6 +11390,8 @@ public class HistoryETL implements TalendJob {
 
 		int exitCode = HistoryETLClass.runJobInTOS(args);
 
+		org.ovirt.engine.dwh.etltermination.Termination.stop();
+		
 		System.exit(exitCode);
 	}
 

--- a/ovirt-engine-dwh.spec.in
+++ b/ovirt-engine-dwh.spec.in
@@ -102,7 +102,6 @@ Requires:	jackson-databind
 Requires:	jackson-annotations
 Requires:	logrotate
 Requires:	postgresql-jdbc
-Requires:	python3-psycopg2
 
 Requires:       postgresql-server >= 12.0
 Requires:       postgresql-contrib >= 12.0

--- a/ovirt-engine-dwh/etltermination/src/main/java/org/ovirt/engine/dwh/etltermination/Termination.java
+++ b/ovirt-engine-dwh/etltermination/src/main/java/org/ovirt/engine/dwh/etltermination/Termination.java
@@ -5,6 +5,7 @@ public class Termination {
     private static volatile Termination instance;
 
     private boolean terminate;
+    private boolean stopped;
 
     public static Termination getInstance() {
         if (instance == null) {
@@ -17,10 +18,29 @@ public class Termination {
         return instance;
     }
 
+    public static void stop() {
+        System.out.println("Termination.stop() called");
+        getInstance().stopped = true;
+    }
+
     private Termination() {
         terminate = false;
+        stopped = false;
+        
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             terminate = true;
+            
+            System.out.println("Shutdown hook waiting for stop() to be called...");
+            while (!stopped) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    System.out.println("Shutdown hook interrupted while waiting: " + e.getMessage());
+                    break;
+                }
+            }
+            System.out.println("Shutdown hook exiting - cleanup completed");
         }));
     }
 

--- a/packaging/services/ovirt-engine-dwhd/ovirt-engine-dwhd.py
+++ b/packaging/services/ovirt-engine-dwhd/ovirt-engine-dwhd.py
@@ -100,60 +100,6 @@ class Daemon(service.Daemon):
                 mustExist=False,
             )
 
-    def _executeEngineDbQuery(self, query, params, operation_description):
-        """
-        Execute a query on the engine database.
-        
-        Args:
-            query: SQL query string
-            params: Tuple of parameters for the query
-            operation_description: Description of the operation for logging
-            
-        Returns:
-            True on success, False on failure
-        """
-        try:
-            import psycopg2
-            
-            conn = psycopg2.connect(
-                host=self._config.get('ENGINE_DB_HOST'),
-                port=self._config.get('ENGINE_DB_PORT'),
-                database=self._config.get('ENGINE_DB_DATABASE'),
-                user=self._config.get('ENGINE_DB_USER'),
-                password=self._config.get('ENGINE_DB_PASSWORD'),
-                connect_timeout=10
-            )
-            
-            try:
-                cur = conn.cursor()
-                cur.execute(query, params)
-                conn.commit()
-                cur.close()
-                
-                self.logger.debug('Successfully %s', operation_description)
-                return True
-            finally:
-                conn.close()
-                
-        except ImportError:
-            self.logger.warning(
-                'psycopg2 module not available, cannot %s', operation_description
-            )
-            return False
-        except Exception as e:
-            self.logger.warning(
-                'Exception while %s: %s', operation_description, e
-            )
-            return False
-
-    def externalProcessGracefulShutdown(self, process):
-        self.logger.info('Setting DisconnectDwh flag to request graceful shutdown')
-        return self._executeEngineDbQuery(
-            "UPDATE vdc_options SET option_value = %s WHERE option_name = %s",
-            ('1', 'DisconnectDwh'),
-            'set DisconnectDwh flag to 1'
-        )
-
     def daemonSetup(self):
 
         if os.geteuid() == 0:
@@ -282,13 +228,6 @@ class Daemon(service.Daemon):
         return (consoleLog, consoleLog)
 
     def daemonContext(self):
-        self.logger.info('Resetting DisconnectDwh flag to 0')
-        self._executeEngineDbQuery(
-            "UPDATE vdc_options SET option_value = %s WHERE option_name = %s",
-            ('0', 'DisconnectDwh'),
-            'reset DisconnectDwh flag to 0'
-        )
-
         self.daemonAsExternalProcess(
             executable=self._executable,
             args=self._serviceArgs,


### PR DESCRIPTION
Relying on `DisconnectDwh` and receiving a signal at the same time doesn't work. Systemd relays the signal to the whole control-group, not just the python wrapper. This creates a race condition in which the cleanup doesn't get executed most of the time. Because of this the `DwhCurrentlyRunning` flag stays set to `1`, which makes the ovirt-engine-setup fail.

New aproach:
- shutdownhook set terminate to true
- this triggers the talend code to stop
- shutdownhook then waits for stopped boolean to be true
- stopped is set to true right before calling `System.exit(exitCode)`

+ undo the previously made changes

TODO: we should properly fix this in the future as we now make changes to auto-generated code (HistoryETL.java)