### PR TITLE
packaging: add ongres-scram/stringprep to classpath

### DIFF
--- a/packaging/bin/dwh-classpath.sh
+++ b/packaging/bin/dwh-classpath.sh
@@ -47,10 +47,15 @@ if [ -x /usr/bin/build-classpath ]; then
 	jackson_annotations="$(build-classpath jackson-annotations 2> /dev/null)"
 	[ -z "${jackson_annotations}" ] && jackson_annotations="$(build-classpath jackson-annotations 2> /dev/null)"
 	[ -n "${jackson_annotations}" ] || die "Cannot find jackson-annotations"
+	output="${output}:${dom4j}:${commons_collections}:${jackson_core}:${jackson_databind}:${jackson_annotations}"
 	if [ "${what}" = "run" ]; then
-		postgresql_jdbc="$(build-classpath postgresql-jdbc)" || die "Canot find postgreql-jdbc"
+		postgresql_jdbc="$(build-classpath postgresql-jdbc)" || die "Cannot find postgreql-jdbc"
+		output="${output}:${postgresql_jdbc}"
+		ongres_scram="$(build-classpath ongres-scram)"
+		[ -n "${ongres_scram}" ] && output="${output}:${ongres_scram}"
+		ongres_stringprep="$(build-classpath ongres-stringprep)"
+		[ -n "${ongres_stringprep}" ] && output="${output}:${ongres_stringprep}"
 	fi
-	output="${output}:${dom4j}:${commons_collections}:${jackson_core}:${jackson_databind}:${jackson_annotations}:${postgresql_jdbc}"
 else
 	die "Cannot find a method to acquire dependencies"
 fi

--- a/packaging/bin/dwh-classpath.sh
+++ b/packaging/bin/dwh-classpath.sh
@@ -31,21 +31,7 @@ if [ -z "${WILDFLYJAVACONF}" ]; then
 	WILDFLYJAVACONFDIR="$(readlink -f $(dirname $(dirname $0)))/wildflyjavaconf"
 fi
 
-if [ -x /usr/bin/java-config ]; then
-	PACKAGES_BUILD="dom4j-1 commons-collections jackson-core jackson-databind jackson-annotations"
-	PACKAGES_RUNTIME="jdbc-postgresql"
-
-	packages="${PACKAGES_BUILD}"
-	args=
-	if [ "${what}" = "run" ]; then
-		packages="${packages} ${PACKAGES_RUNTIME}"
-		args="${args} -d"
-	fi
-	for package in ${packages}; do
-		output="${output}:$(java-config ${args} -p ${package} 2> /dev/null)" \
-			|| die "Cannot locate ${package}"
-	done
-elif [ -x /usr/bin/build-classpath ]; then
+if [ -x /usr/bin/build-classpath ]; then
 	dom4j="$(build-classpath dom4j 2> /dev/null)"
 	[ -z "${dom4j}" ] && dom4j="$(JAVACONFDIRS=${WILDFLYJAVACONFDIR} build-classpath dom4j 2> /dev/null)"
 	[ -n "${dom4j}" ] || die "Cannot find dom4j"


### PR DESCRIPTION
To be able to connect to PostgreSQL servers with scram password encoding, the postgresql-jdbc lib needs ongres-scram and ongres-stringprep.

So we need to add those jar's to the classpath to make sure this works.

Fixes: #78